### PR TITLE
v0.21.3: fix `-o` flag + default output dir (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## v0.21.3 — "Write Where I Told You" (2026-04-16)
+
+Short, late-night fix. Found this while testing `preset` behavior — noticed
+that `nyx build hello.nyx -o /tmp/out/page.html` silently dropped the flag
+and wrote to `./dist-site/index.html` instead. Two latent bugs, one patch.
+
+### Fixes
+
+- **#82 — `nyx build` now honors `-o` / `--output`, and defaults output
+  next to the input file.** Two separate problems:
+
+  1. **Flag was never implemented.** `-o path/to/file.html`,
+     `--output path/`, and `--output=path/` are all parsed now. A
+     `.html` path produces single-file output; anything else is treated
+     as a directory. Passing `-o file.html` against a multi-page
+     project now errors out instead of silently discarding pages.
+
+  2. **Default output was CWD-relative.** The old code did
+     `resolve('dist-site')`, so running `nyx build /a/b/site.nyx` from
+     `/tmp` dumped the build in `/tmp/dist-site/`. The new default is
+     `<input-file-dir>/dist-site/` — sibling of the input file, like
+     every other build tool.
+
+  The fix is mirrored in `nyx watch`, which had the same hard-coded
+  default.
+
+### Docs
+
+- `nyx --help` now lists the `-o <path>` option and gives two
+  copy-paste examples (single-file and directory forms).
+
+---
+
 ## v0.21.2 — "Version, Plural" (2026-04-16)
 
 Dogfooding-triggered patch: Kiro 🐺 was writing a site-wide footer in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabudde/nyxcode",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "NyxCode — The AI-native programming language for the web. 68% fewer tokens than React.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -308,6 +308,25 @@ const args = process.argv.slice(2);
 const command = args[0];
 const file = args[1];
 
+/**
+ * Parse --output / -o flag from args. Supports:
+ *   -o path/to/file.html       → single-file output
+ *   --output path/to/dir/      → directory output
+ *   -o=path/to/thing           → equals-form
+ * Returns the path string, or null if not present.
+ */
+function getOutputFlag(argv: string[]): string | null {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '-o' || a === '--output') {
+      return argv[i + 1] ?? null;
+    }
+    if (a.startsWith('-o=')) return a.slice(3);
+    if (a.startsWith('--output=')) return a.slice(9);
+  }
+  return null;
+}
+
 if (!command || (command !== 'dev' && !file) || (!file && command !== '--help')) {
   console.log(`
 🦞 NyxCode v${JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version}
@@ -316,16 +335,21 @@ Usage:
   nyx parse <file.nyx>              Parse file → AST (JSON)
   nyx flatten <file.nyx>            Flatten multi-file project to single .nyx source
   nyx tokens <file.nyx>             Tokenize file → Token list
-  nyx build <file.nyx>              Compile file → HTML output
-  nyx watch <file.nyx>              Watch file & rebuild on change
+  nyx build <file.nyx> [-o <path>]  Compile file → HTML output
+  nyx watch <file.nyx> [-o <path>]  Watch file & rebuild on change
   nyx dev <file.nyx> [--port=3000]  Dev server with live reload
 
 Examples:
   nyx parse examples/hello.nyx
   nyx build examples/hello.nyx
+  nyx build examples/hello.nyx -o build/index.html    # single-file output
+  nyx build examples/hello.nyx -o public/             # directory output
   nyx watch examples/landing.nyx
   nyx dev examples/docs.nyx
   nyx dev examples/landing.nyx --port=8080
+
+Output:
+  Without -o: defaults to <input-file-dir>/dist-site/
 `);
   process.exit(0);
 }
@@ -443,14 +467,40 @@ try {
 
     // Count pages to determine output mode
     const pages = ast.body.filter((n: any) => n.type === 'Page');
-    const outDir = resolve('dist-site');
+
+    // Resolve output path (Issue #82):
+    //  -o <file.html>   → single-file output (error if multi-page)
+    //  -o <dir>         → use as output directory
+    //  (no flag)        → default to <input-file-dir>/dist-site/ (sibling of input)
+    const outputFlag = getOutputFlag(args);
+    let outDir: string;
+    let singleFilePath: string | null = null;
+
+    if (outputFlag) {
+      const outResolved = resolve(outputFlag);
+      const looksLikeFile = extname(outputFlag).toLowerCase() === '.html';
+      if (looksLikeFile) {
+        if (pages.length > 1) {
+          console.error(`\x1b[31m❌ Cannot use -o <file.html> with a multi-page project (${pages.length} pages). Pass a directory path instead, e.g. -o ./build/\x1b[0m`);
+          process.exit(1);
+        }
+        singleFilePath = outResolved;
+        outDir = dirname(outResolved);
+      } else {
+        outDir = outResolved;
+      }
+    } else {
+      // Default: sibling of input file (not CWD)
+      outDir = resolve(dirname(filePath), 'dist-site');
+    }
 
     if (pages.length <= 1) {
       // Single page — legacy behavior: one index.html
       const output = compiler.compile(ast);
       mkdirSync(outDir, { recursive: true });
-      writeFileSync(resolve(outDir, 'index.html'), output.html);
-      console.log(`✅ Built: ${outDir}/index.html`);
+      const outFile = singleFilePath ?? resolve(outDir, 'index.html');
+      writeFileSync(outFile, output.html);
+      console.log(`✅ Built: ${outFile}`);
       console.log(`   HTML: ${output.html.length} bytes`);
       if (output.css) console.log(`   CSS:  ${output.css.length} bytes`);
       if (output.js) console.log(`   JS:   ${output.js.length} bytes`);
@@ -461,9 +511,9 @@ try {
 
       for (const { path: pagePath, html } of results) {
         // Convert route to file path:
-        //   /docs        → dist-site/docs/index.html
-        //   /docs/install → dist-site/docs/install/index.html
-        //   /            → dist-site/index.html
+        //   /docs        → <outDir>/docs/index.html
+        //   /docs/install → <outDir>/docs/install/index.html
+        //   /            → <outDir>/index.html
         let fileDirPath: string;
         if (pagePath === '/') {
           fileDirPath = outDir;
@@ -476,7 +526,7 @@ try {
         totalBytes += html.length;
       }
 
-      console.log(`✅ Built: ${results.length} pages to dist-site/`);
+      console.log(`✅ Built: ${results.length} pages to ${outDir}/`);
       console.log(`   Total: ${totalBytes} bytes`);
       for (const { path: pagePath } of results) {
         const rel = pagePath === '/' ? 'index.html' : pagePath.replace(/^\//, '').replace(/\/+$/, '') + '/index.html';
@@ -616,14 +666,36 @@ try {
         const compiler = new Compiler({ pretty: true });
 
         const pages = ast.body.filter((n: any) => n.type === 'Page');
-        const outDir = resolve('dist-site');
+
+        // Resolve output path (Issue #82) — mirrors build-command logic
+        const outputFlag = getOutputFlag(args);
+        let outDir: string;
+        let singleFilePath: string | null = null;
+        if (outputFlag) {
+          const outResolved = resolve(outputFlag);
+          const looksLikeFile = extname(outputFlag).toLowerCase() === '.html';
+          if (looksLikeFile) {
+            if (pages.length > 1) {
+              console.error(`\x1b[31m❌ Cannot use -o <file.html> with multi-page project. Use a directory.\x1b[0m`);
+              return { ok: false, pages: 0, bytes: 0, ms: performance.now() - start };
+            }
+            singleFilePath = outResolved;
+            outDir = dirname(outResolved);
+          } else {
+            outDir = outResolved;
+          }
+        } else {
+          outDir = resolve(dirname(filePath), 'dist-site');
+        }
+
         let totalBytes = 0;
         let pageCount = 0;
 
         if (pages.length <= 1) {
           const output = compiler.compile(ast);
           mkdirSync(outDir, { recursive: true });
-          writeFileSync(resolve(outDir, 'index.html'), output.html);
+          const outFile = singleFilePath ?? resolve(outDir, 'index.html');
+          writeFileSync(outFile, output.html);
           totalBytes = output.html.length;
           pageCount = 1;
         } else {


### PR DESCRIPTION
Fixes #82.

Two bugs, one patch:

1. **`-o` / `--output` was silently dropped.** Now parsed. Supports:
   - `-o path/to/file.html` → single-file output
   - `-o path/to/dir/` → directory output
   - `--output=path` equals-form
   - Multi-page + `-o file.html` now errors instead of silently dropping pages

2. **Default output was CWD-relative** (`resolve('dist-site')`). Running
   `nyx build /a/b/site.nyx` from `/tmp` dumped to `/tmp/dist-site/`.
   Now defaults to `<input-file-dir>/dist-site/` — sibling of input.

Mirrored fix in `nyx watch`. Updated `nyx --help`.

### Test matrix (all green)
- no flag, single-page → input-dir/dist-site/index.html ✅
- `-o file.html`, single-page → exact path ✅
- `-o dir/`, single-page → dir/index.html ✅
- `--output=dir` equals-form → works ✅
- no flag, multi-page → input-dir/dist-site/{page}/index.html ✅
- `-o dir/`, multi-page → dir/{page}/index.html ✅
- `-o file.html`, multi-page → ERROR (exit 1) ✅
- Regression: counter.nyx, docs.nyx (12 pages), ai-rights.nyx → all build ✅