### PR TITLE
fix(auth-ux): login/registration now visibly works (visible=auth/guest + logout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.54.1 — Auth UX fixes (2026-06-21)
+
+Login/registration *worked* (JWT issued, stored) but gave no visible feedback, so
+it looked broken. Fixed end-to-end:
+
+- **`success -> navigate "/path"` now works in forms.** It was parsed without its
+  value and dropped, so login/register stored the token but never redirected.
+  `navigate`/`go` are now first-class form success actions.
+- **`visible="auth"/"guest"` works on single-page apps.** The runtime toggle script
+  (show/hide by JWT presence) was only injected on the multi-page path, so a
+  single-page app never reflected logged-in state. Now injected in both.
+- **Native `logout` action** — `on:click { logout }` clears the JWT and redirects
+  (optionally `logout "/path"`).
+- `examples/vegan-maps.nyx` header now shows **Sign in ↔ Signed in / Sign out**,
+  verified in a real headless-Chrome run (register → redirect → logged-in header →
+  save favorite → logout). Live at vegan.heynyx.dev.
+
+---
+
 ## v0.54.0 — "Native Maps, Zero Hacks" (2026-06-21)
 
 Make whole classes of interactive apps buildable in 100% NyxCode — no `script {}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ it looked broken. Fixed end-to-end:
   single-page app never reflected logged-in state. Now injected in both.
 - **Native `logout` action** — `on:click { logout }` clears the JWT and redirects
   (optionally `logout "/path"`).
+- **Logical operators in handler expressions.** `set x = not y`, `a and b`, `a or b`
+  used to emit the literal words `not`/`and`/`or` → invalid JS → the handler silently
+  did nothing (this is why the VeganMaps "fully vegan" toggle never flipped). They
+  now compile to `!`/`&&`/`||`.
+- VeganMaps: the toggle now flips fully-vegan ↔ vegan-options (with a reactive
+  label), and a **"My favorites"** list (logged-in only) makes saving spots useful.
 - `examples/vegan-maps.nyx` header now shows **Sign in ↔ Signed in / Sign out**,
   verified in a real headless-Chrome run (register → redirect → logged-in header →
   save favorite → logout). Live at vegan.heynyx.dev.

--- a/benchmarks/veganmaps/RESULTS.md
+++ b/benchmarks/veganmaps/RESULTS.md
@@ -1,0 +1,75 @@
+# VeganMaps: NyxCode vs Next.js
+
+The same app — a live vegan-restaurant map (OpenStreetMap + Overpass) with user
+accounts (JWT), a favorites system (SQLite), search, a fully-vegan/vegan-options
+toggle, and "near me" geolocation — built twice.
+
+- **NyxCode**: [`examples/vegan-maps.nyx`](../../examples/vegan-maps.nyx) — live at https://vegan.heynyx.dev
+- **Next.js**: [`nextjs/`](./nextjs) — App Router + better-sqlite3 + jsonwebtoken + Leaflet
+
+## By the numbers
+
+| | NyxCode | Next.js | |
+|---|---|---|---|
+| Files (source) | **1** | 10 (+3 config) | 13× fewer |
+| Code lines (excl. comments/blank) | **129** | 383 | ~3× fewer |
+| Source bytes | **9.6 KB** | 21.3 KB | 2.1× smaller |
+| Approx. tokens | **~2.4k** | ~5.0k | 2.1× fewer |
+| Hand-written backend | `table` + `security` (~12 lines) | db.ts + auth.ts + 3 route handlers (~95 lines) | |
+| Map | declarative `map`/`marker` (~12 lines) | 138-line imperative client component | |
+| Config to author | **none** (auto-generated) | package.json, tsconfig, next.config | |
+
+> Token counts are the chars/4 heuristic on source only (no `node_modules`, no
+> lockfiles). The gap widens once you count the config/boilerplate a Next.js repo
+> needs and an AI has to emit or keep consistent.
+
+## Honest assessment — what's actually better where
+
+This is not a hit piece on either side. I built both; here's the straight call.
+
+### Where NyxCode genuinely wins
+- **Density & one mental model.** 1 file, ~2.4k tokens, no build config. The whole
+  app fits in a single context window with room to spare.
+- **The full-stack stuff is nearly free.** `table favorites { user [users] … }` +
+  `security { … }` gave me SQLite, migrations, a JWT register/login flow, a CRUD API,
+  and per-user protected routes in ~12 lines. In Next.js I hand-wrote `lib/db.ts`,
+  `lib/auth.ts`, and three route handlers (~95 lines) for the same thing.
+- **Declarative map.** `map source="overpass" … { marker … }` vs a 138-line React
+  component wiring Leaflet, debounced refetch, refs, and effect dependencies by hand.
+- **AI economy.** Fewer tokens, far less surface area to get wrong, one file to edit.
+  For AI-written code this is a real, measurable advantage.
+
+### Where Next.js genuinely wins (and it's not close)
+- **Type safety.** Real end-to-end TypeScript: a `Place` interface, typed API
+  payloads, compile-time errors. NyxCode is dynamically typed — and building this app
+  surfaced exactly the class of bug a typed/mature compiler prevents: `set x = not y`
+  emitted the literal word `not` (invalid JS, the toggle silently died); the arrow
+  handler form swallowed a trailing `style=`; `success -> navigate` was dropped. I had
+  to fix the **compiler itself** ~5 times to finish this app. Next.js wouldn't have hit
+  any of those.
+- **Ecosystem & maturity.** npm, react-leaflet, SSR, middleware, a decade of Stack
+  Overflow. NyxCode is young; you live within what the compiler supports, and you hit
+  walls.
+- **Debugging & tooling.** Source maps, real stack traces, React DevTools, a full LSP,
+  refactoring, ESLint. NyxCode generates code — debugging the output is indirect, and
+  editor support is basic.
+- **Hiring & longevity.** Millions know React. Approximately nobody knows NyxCode.
+
+### My verdict
+For **this app**, and for **AI-first development where token economy and a single
+coherent file matter more than ecosystem**, NyxCode is genuinely better — dramatically
+less code, and auth/DB/API/map are almost free. That conciseness is real.
+
+But it rests on a **young compiler**. Shipping this exposed several real language bugs I
+had to fix as I went. Today, for a team shipping production software, **Next.js is the
+safer, more powerful, more debuggable, more hireable choice** — type safety and a mature
+ecosystem are worth a lot more than they look on a line-count table.
+
+NyxCode's bet is that AI writes most code and that tokens + coherence will matter more
+than ecosystem depth. The 2× density gap is real and the DX is improving fast. If it
+keeps closing the robustness/type-safety gap, that bet gets very hard to argue against
+for AI-generated apps. It isn't there yet — but the direction is right.
+
+*Built and measured 2026-06-21. The NyxCode version is verified running live; the
+Next.js version is written idiomatically (standard App Router patterns) but a full
+`next build` was not run in this environment.*

--- a/benchmarks/veganmaps/nextjs/.gitignore
+++ b/benchmarks/veganmaps/nextjs/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+*.db
+*.db-*
+next-env.d.ts

--- a/benchmarks/veganmaps/nextjs/app/api/auth/login/route.ts
+++ b/benchmarks/veganmaps/nextjs/app/api/auth/login/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import bcrypt from 'bcryptjs';
+import db from '@/lib/db';
+import { sign } from '@/lib/auth';
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
+  const user = db.prepare('SELECT * FROM users WHERE email = ?').get(email) as
+    | { id: number; email: string; password: string }
+    | undefined;
+  if (!user || !bcrypt.compareSync(password, user.password)) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+  }
+  return NextResponse.json({ token: sign({ id: user.id, email: user.email }), user: { id: user.id, email: user.email } });
+}

--- a/benchmarks/veganmaps/nextjs/app/api/auth/register/route.ts
+++ b/benchmarks/veganmaps/nextjs/app/api/auth/register/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import bcrypt from 'bcryptjs';
+import db from '@/lib/db';
+import { sign } from '@/lib/auth';
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
+  if (!email || !password) {
+    return NextResponse.json({ error: 'email and password required' }, { status: 400 });
+  }
+  const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(email);
+  if (existing) {
+    return NextResponse.json({ error: 'User already exists' }, { status: 409 });
+  }
+  const hash = bcrypt.hashSync(password, 10);
+  const info = db.prepare('INSERT INTO users (email, password) VALUES (?, ?)').run(email, hash);
+  const user = { id: Number(info.lastInsertRowid), email };
+  return NextResponse.json({ token: sign(user), user });
+}

--- a/benchmarks/veganmaps/nextjs/app/api/favorites/route.ts
+++ b/benchmarks/veganmaps/nextjs/app/api/favorites/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import db from '@/lib/db';
+import { userFromRequest } from '@/lib/auth';
+
+export async function GET(req: NextRequest) {
+  const u = userFromRequest(req);
+  if (!u) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const rows = db.prepare('SELECT id, name, lat, lon FROM favorites WHERE user = ?').all(u.id);
+  return NextResponse.json(rows);
+}
+
+export async function POST(req: NextRequest) {
+  const u = userFromRequest(req);
+  if (!u) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { name, lat, lon } = await req.json();
+  if (!name) return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  const info = db
+    .prepare('INSERT INTO favorites (user, name, lat, lon) VALUES (?, ?, ?, ?)')
+    .run(u.id, name, lat, lon);
+  return NextResponse.json({ id: Number(info.lastInsertRowid), name, lat, lon });
+}

--- a/benchmarks/veganmaps/nextjs/app/globals.css
+++ b/benchmarks/veganmaps/nextjs/app/globals.css
@@ -1,0 +1,7 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body { height: 100%; }
+body { background: #0b1410; color: #eafff3; font-family: 'Inter', system-ui, sans-serif; }
+.leaflet-popup-content-wrapper { background: #10231a; color: #eafff3; border-radius: 14px; border: 1px solid rgba(52,211,153,0.25); }
+.leaflet-popup-tip { background: #10231a; }
+.leaflet-container a.leaflet-popup-close-button { color: #9fe9c6; }
+.vm-card:hover { background: rgba(52,211,153,0.08); }

--- a/benchmarks/veganmaps/nextjs/app/layout.tsx
+++ b/benchmarks/veganmaps/nextjs/app/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'VeganMaps — 100% Vegan Restaurants',
+  description: 'Discover fully vegan restaurants on a live map.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossOrigin=""
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+        />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/benchmarks/veganmaps/nextjs/app/login/page.tsx
+++ b/benchmarks/veganmaps/nextjs/app/login/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const [msg, setMsg] = useState('');
+
+  const submit = (path: string) => async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    const r = await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: form.get('email'), password: form.get('password') }),
+    });
+    const d = await r.json();
+    if (r.ok) {
+      if (d.token) localStorage.setItem('token', d.token);
+      location.href = '/';
+    } else {
+      setMsg(d.error || 'Error');
+    }
+  };
+
+  const inputStyle: React.CSSProperties = { width: '100%', padding: '0.7rem 0.9rem', marginBottom: '0.8rem', borderRadius: 10, border: '1px solid rgba(52,211,153,0.22)', background: 'rgba(255,255,255,0.04)', color: '#eafff3' };
+
+  return (
+    <div style={{ maxWidth: 380, margin: '8vh auto', padding: '2rem', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(52,211,153,0.18)', borderRadius: 18 }}>
+      <div style={{ fontWeight: 800, fontSize: '1.5rem', textAlign: 'center', marginBottom: '0.5rem' }}>
+        🌱 Vegan<span style={{ color: '#34d399' }}>Maps</span>
+      </div>
+      <p style={{ textAlign: 'center', color: 'rgba(234,255,243,0.55)', marginBottom: '1.5rem', fontSize: '0.9rem' }}>Sign in to save your favorite vegan spots.</p>
+
+      <form onSubmit={submit('/api/auth/login')}>
+        <input name="email" type="email" placeholder="Email" style={inputStyle} required />
+        <input name="password" type="password" placeholder="Password" style={{ ...inputStyle, marginBottom: '1rem' }} required />
+        <button type="submit" style={{ width: '100%', padding: '0.75rem', border: 'none', borderRadius: 10, background: '#34d399', color: '#07140b', fontWeight: 700, cursor: 'pointer' }}>Sign in</button>
+      </form>
+
+      <p style={{ textAlign: 'center', color: 'rgba(234,255,243,0.45)', margin: '1.2rem 0 0.6rem', fontSize: '0.82rem' }}>New here? Create an account below.</p>
+      <form onSubmit={submit('/api/auth/register')}>
+        <input name="email" type="email" placeholder="Email" style={inputStyle} required />
+        <input name="password" type="password" placeholder="Choose a password" style={{ ...inputStyle, marginBottom: '1rem' }} required />
+        <button type="submit" style={{ width: '100%', padding: '0.75rem', borderRadius: 10, background: 'rgba(163,230,53,0.15)', color: '#a3e635', fontWeight: 700, cursor: 'pointer', border: '1px solid rgba(163,230,53,0.4)' }}>Create account</button>
+      </form>
+
+      {msg && <p style={{ textAlign: 'center', color: '#fb7185', marginTop: '1rem', fontSize: '0.85rem' }}>{msg}</p>}
+      <a href="/" style={{ display: 'block', textAlign: 'center', marginTop: '1.2rem', color: '#9fe9c6', textDecoration: 'none', fontSize: '0.85rem' }}>← Back to map</a>
+    </div>
+  );
+}

--- a/benchmarks/veganmaps/nextjs/app/page.tsx
+++ b/benchmarks/veganmaps/nextjs/app/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { useEffect, useRef, useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
+import type * as L from 'leaflet';
+import type { Place } from '@/components/VeganMap';
+
+const VeganMap = dynamic(() => import('@/components/VeganMap'), { ssr: false });
+
+interface Fav { id: number; name: string; lat: number; lon: number; }
+
+export default function Home() {
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [query, setQuery] = useState('');
+  const [onlyVegan, setOnlyVegan] = useState(true);
+  const [token, setToken] = useState<string | null>(null);
+  const [favs, setFavs] = useState<Fav[]>([]);
+  const mapRef = useRef<L.Map | null>(null);
+
+  useEffect(() => { setToken(localStorage.getItem('token')); }, []);
+
+  const loadFavs = useCallback(async (tk: string) => {
+    const r = await fetch('/api/favorites', { headers: { Authorization: 'Bearer ' + tk } });
+    if (r.ok) setFavs(await r.json());
+  }, []);
+
+  useEffect(() => { if (token) loadFavs(token); }, [token, loadFavs]);
+
+  const save = async (p: Place) => {
+    if (!token) { location.href = '/login'; return; }
+    const r = await fetch('/api/favorites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
+      body: JSON.stringify({ name: p.name, lat: p.lat, lon: p.lon }),
+    });
+    if (r.ok) loadFavs(token);
+  };
+
+  const locate = () => {
+    if (!navigator.geolocation || !mapRef.current) return;
+    navigator.geolocation.getCurrentPosition((pos) =>
+      mapRef.current!.setView([pos.coords.latitude, pos.coords.longitude], 15),
+    );
+  };
+
+  const logout = () => { localStorage.removeItem('token'); setToken(null); setFavs([]); };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
+      <header style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.8rem 1.2rem', background: 'rgba(11,20,16,0.92)', borderBottom: '1px solid rgba(52,211,153,0.18)', flexWrap: 'wrap', zIndex: 1000 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontWeight: 800, fontSize: '1.25rem' }}>
+          <span>🌱</span><span>Vegan</span><span style={{ color: '#34d399', marginLeft: '-0.35rem' }}>Maps</span>
+        </div>
+        <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Filter visible places…"
+          style={{ flex: 1, minWidth: 200, maxWidth: 420, padding: '0.6rem 0.9rem', borderRadius: 10, border: '1px solid rgba(52,211,153,0.22)', background: 'rgba(255,255,255,0.04)', color: '#eafff3', outline: 'none' }} />
+        <button onClick={() => setOnlyVegan((v) => !v)} style={{ padding: '0.55rem 0.9rem', borderRadius: 10, border: '1px solid rgba(52,211,153,0.35)', background: 'rgba(52,211,153,0.14)', color: '#eafff3', fontWeight: 600, cursor: 'pointer' }}>
+          {onlyVegan ? '🥗 Fully vegan' : '🌿 Vegan options'}
+        </button>
+        <button onClick={locate} style={{ padding: '0.55rem 0.9rem', borderRadius: 10, border: '1px solid rgba(163,230,53,0.4)', background: 'rgba(163,230,53,0.12)', color: '#eafff3', fontWeight: 600, cursor: 'pointer' }}>📍 Near me</button>
+        {token ? (
+          <>
+            <span style={{ padding: '0.55rem 0.75rem', borderRadius: 10, border: '1px solid rgba(52,211,153,0.25)', color: '#34d399', fontWeight: 600, fontSize: '0.85rem' }}>🌱 Signed in</span>
+            <button onClick={logout} style={{ padding: '0.55rem 0.9rem', borderRadius: 10, border: '1px solid rgba(251,113,133,0.4)', background: 'rgba(251,113,133,0.12)', color: '#fb7185', fontWeight: 600, cursor: 'pointer' }}>Sign out</button>
+          </>
+        ) : (
+          <a href="/login" style={{ padding: '0.55rem 0.9rem', borderRadius: 10, border: '1px solid rgba(52,211,153,0.25)', color: '#9fe9c6', textDecoration: 'none', fontWeight: 600 }}>Sign in</a>
+        )}
+      </header>
+
+      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        <aside style={{ width: 340, maxWidth: '42vw', display: 'flex', flexDirection: 'column', borderRight: '1px solid rgba(52,211,153,0.15)', background: 'rgba(7,14,11,0.6)' }}>
+          <div style={{ padding: '0.9rem 1.1rem', borderBottom: '1px solid rgba(52,211,153,0.12)', fontWeight: 700 }}>
+            Results <span style={{ color: '#34d399' }}>{places.length}</span>
+          </div>
+          <div style={{ overflowY: 'auto', flex: 1, padding: '0.6rem' }}>
+            {places.length === 0 ? (
+              <div style={{ padding: '1.4rem 1rem', color: 'rgba(234,255,243,0.5)', textAlign: 'center', fontSize: '0.9rem' }}>Move the map to discover vegan places.</div>
+            ) : places.map((p) => (
+              <div key={p.id} className="vm-card" style={{ padding: '0.7rem 0.8rem', border: '1px solid rgba(52,211,153,0.14)', borderRadius: 12, marginBottom: '0.5rem' }}>
+                <div style={{ fontWeight: 600, marginBottom: 2 }}>{p.name}</div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+                  <span style={{ color: '#34d399', fontSize: '0.74rem', fontWeight: 600 }}>{p.diet}</span>
+                  <button onClick={() => save(p)} style={{ background: 'none', border: '1px solid rgba(163,230,53,0.4)', color: '#a3e635', borderRadius: 8, padding: '2px 8px', fontSize: '0.74rem', cursor: 'pointer' }}>♥ Save</button>
+                </div>
+              </div>
+            ))}
+          </div>
+          {token && (
+            <div style={{ borderTop: '1px solid rgba(52,211,153,0.18)', maxHeight: '42%', overflowY: 'auto', padding: '0.7rem 0.8rem' }}>
+              <div style={{ fontWeight: 700, color: '#a3e635', fontSize: '0.85rem', marginBottom: '0.5rem' }}>★ My favorites</div>
+              {favs.length === 0 ? (
+                <div style={{ color: 'rgba(234,255,243,0.5)', fontSize: '0.82rem', padding: '0.3rem' }}>No saved spots yet — tap ♥ Save on a place.</div>
+              ) : favs.map((f) => (
+                <div key={f.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, padding: '0.4rem 0.5rem', border: '1px solid rgba(163,230,53,0.14)', borderRadius: 10, marginBottom: '0.4rem' }}>
+                  <span style={{ fontSize: '0.84rem' }}>{f.name}</span>
+                  <a href={`https://www.google.com/maps/dir/?api=1&destination=${f.lat},${f.lon}`} target="_blank" style={{ color: '#a3e635', fontSize: '0.76rem', textDecoration: 'none' }}>↗ Map</a>
+                </div>
+              ))}
+            </div>
+          )}
+        </aside>
+
+        <div style={{ flex: 1, position: 'relative', minWidth: 0 }}>
+          <VeganMap strict={onlyVegan} query={query} onPlaces={setPlaces} onMapReady={(m) => { mapRef.current = m; }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/benchmarks/veganmaps/nextjs/components/VeganMap.tsx
+++ b/benchmarks/veganmaps/nextjs/components/VeganMap.tsx
@@ -1,0 +1,138 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import type * as L from 'leaflet';
+
+export interface Place {
+  id: string;
+  lat: number;
+  lon: number;
+  name: string;
+  cuisine: string;
+  address: string;
+  hours: string;
+  website: string;
+  phone: string;
+  diet: string;
+}
+
+function esc(s: unknown): string {
+  return String(s ?? '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!));
+}
+
+function normalize(els: any[]): Place[] {
+  const seen: Record<string, boolean> = {};
+  const out: Place[] = [];
+  for (const e of els || []) {
+    const lat = e.lat != null ? e.lat : e.center?.lat;
+    const lon = e.lon != null ? e.lon : e.center?.lon;
+    if (lat == null || lon == null) continue;
+    const t = e.tags || {};
+    if (!t.name) continue;
+    const k = `${e.type}/${e.id}`;
+    if (seen[k]) continue;
+    seen[k] = true;
+    const addr: string[] = [];
+    if (t['addr:street']) addr.push(t['addr:street'] + (t['addr:housenumber'] ? ' ' + t['addr:housenumber'] : ''));
+    if (t['addr:city']) addr.push(t['addr:city']);
+    out.push({
+      id: k, lat, lon, name: t.name,
+      cuisine: (t.cuisine || '').replace(/;/g, ', '),
+      address: addr.join(', '), hours: t.opening_hours || '',
+      website: t.website || t['contact:website'] || '',
+      phone: t.phone || t['contact:phone'] || '',
+      diet: t['diet:vegan'] === 'only' ? '100% vegan' : 'vegan options',
+    });
+  }
+  return out;
+}
+
+function popupHtml(p: Place): string {
+  const dir = `https://www.google.com/maps/dir/?api=1&destination=${p.lat},${p.lon}`;
+  return (
+    `<h3 style="font-weight:700;margin-bottom:3px">${esc(p.name)}</h3>` +
+    `<p style="color:#34d399;font-size:.74rem;font-weight:600">${esc(p.diet)}</p>` +
+    (p.cuisine ? `<p style="color:#9fe9c6;font-size:.8rem">${esc(p.cuisine)}</p>` : '') +
+    (p.address ? `<p style="color:rgba(234,255,243,.6);font-size:.78rem">${esc(p.address)}</p>` : '') +
+    `<a href="${esc(dir)}" target="_blank" style="color:#34d399;font-weight:600;font-size:.82rem;text-decoration:none">↗ Directions</a>`
+  );
+}
+
+export default function VeganMap({
+  strict, query, onPlaces, onMapReady,
+}: {
+  strict: boolean;
+  query: string;
+  onPlaces: (p: Place[]) => void;
+  onMapReady: (m: L.Map) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const layerRef = useRef<L.LayerGroup | null>(null);
+  const allRef = useRef<Place[]>([]);
+  const LRef = useRef<typeof L | null>(null);
+  const strictRef = useRef(strict);
+  const queryRef = useRef(query);
+
+  useEffect(() => { strictRef.current = strict; }, [strict]);
+  useEffect(() => { queryRef.current = query; }, [query]);
+
+  const render = () => {
+    const Lmod = LRef.current!, layer = layerRef.current!;
+    const q = queryRef.current.toLowerCase();
+    const shown = allRef.current.filter((p) => !q || p.name.toLowerCase().includes(q));
+    layer.clearLayers();
+    const icon = Lmod.divIcon({
+      className: '',
+      html: '<div style="font-size:26px;line-height:26px">🌱</div>',
+      iconSize: [26, 26], iconAnchor: [13, 26], popupAnchor: [0, -24],
+    });
+    for (const p of shown) {
+      Lmod.marker([p.lat, p.lon], { icon }).bindPopup(popupHtml(p)).addTo(layer);
+    }
+    onPlaces(shown);
+  };
+
+  const lastKey = useRef('');
+  const load = async () => {
+    const map = mapRef.current!;
+    const b = map.getBounds();
+    const bbox = `${b.getSouth().toFixed(4)},${b.getWest().toFixed(4)},${b.getNorth().toFixed(4)},${b.getEast().toFixed(4)}`;
+    const filter = strictRef.current ? '"diet:vegan"="only"' : '"diet:vegan"~"yes|only"';
+    const key = filter + '|' + bbox;
+    if (key === lastKey.current) return;
+    lastKey.current = key;
+    const q = `[out:json][timeout:25];(nwr[${filter}](${bbox}););out center tags 200;`;
+    try {
+      const r = await fetch('https://overpass-api.de/api/interpreter', { method: 'POST', body: 'data=' + encodeURIComponent(q) });
+      const d = await r.json();
+      allRef.current = normalize(d.elements);
+      render();
+    } catch { /* ignore */ }
+  };
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    (async () => {
+      const Lmod = (await import('leaflet')).default;
+      LRef.current = Lmod;
+      if (!containerRef.current || mapRef.current) return;
+      const map = Lmod.map(containerRef.current).setView([52.52, 13.405], 14);
+      Lmod.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+        attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19,
+      }).addTo(map);
+      mapRef.current = map;
+      layerRef.current = Lmod.layerGroup().addTo(map);
+      map.on('moveend', () => { clearTimeout(timer); timer = setTimeout(load, 600); });
+      onMapReady(map);
+      load();
+    })();
+    return () => { clearTimeout(timer); mapRef.current?.remove(); mapRef.current = null; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Re-filter when query changes; refetch when strict changes.
+  useEffect(() => { if (mapRef.current) render(); /* eslint-disable-next-line */ }, [query]);
+  useEffect(() => { if (mapRef.current) { lastKey.current = ''; load(); } /* eslint-disable-next-line */ }, [strict]);
+
+  return <div ref={containerRef} style={{ height: '100%', width: '100%' }} />;
+}

--- a/benchmarks/veganmaps/nextjs/lib/auth.ts
+++ b/benchmarks/veganmaps/nextjs/lib/auth.ts
@@ -1,0 +1,18 @@
+import jwt from 'jsonwebtoken';
+import { NextRequest } from 'next/server';
+
+const SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+
+export function sign(payload: { id: number; email: string }): string {
+  return jwt.sign(payload, SECRET, { expiresIn: '7d' });
+}
+
+export function userFromRequest(req: NextRequest): { id: number; email: string } | null {
+  const auth = req.headers.get('authorization');
+  if (!auth?.startsWith('Bearer ')) return null;
+  try {
+    return jwt.verify(auth.slice(7), SECRET) as { id: number; email: string };
+  } catch {
+    return null;
+  }
+}

--- a/benchmarks/veganmaps/nextjs/lib/db.ts
+++ b/benchmarks/veganmaps/nextjs/lib/db.ts
@@ -1,0 +1,23 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+
+const db = new Database(process.env.DATABASE_PATH || path.join(process.cwd(), 'data.db'));
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS favorites (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    lat REAL,
+    lon REAL
+  );
+`);
+
+export default db;

--- a/benchmarks/veganmaps/nextjs/next.config.js
+++ b/benchmarks/veganmaps/nextjs/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = { reactStrictMode: true };

--- a/benchmarks/veganmaps/nextjs/package.json
+++ b/benchmarks/veganmaps/nextjs/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "veganmaps-nextjs",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "better-sqlite3": "^12.9.0",
+    "jsonwebtoken": "^9.0.2",
+    "leaflet": "^1.9.4",
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/jsonwebtoken": "^9.0.6",
+    "@types/leaflet": "^1.9.12",
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.3",
+    "typescript": "^5.5.0"
+  }
+}

--- a/benchmarks/veganmaps/nextjs/tsconfig.json
+++ b/benchmarks/veganmaps/nextjs/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/examples/vegan-maps.nyx
+++ b/examples/vegan-maps.nyx
@@ -61,8 +61,10 @@ page / {
         span "Maps" style="color:#34d399;margin-left:-0.35rem"
       }
       input bind="query" placeholder="Filter visible places…" style="flex:1;min-width:200px;max-width:420px;padding:0.6rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.22);background:rgba(255,255,255,0.04);color:#eafff3;outline:none"
-      button "🥗 Fully vegan" on:click -> set onlyVegan = not onlyVegan style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.35);background:rgba(52,211,153,0.14);color:#eafff3;font-weight:600;cursor:pointer"
-      button "📍 Near me" on:click -> locate style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(163,230,53,0.4);background:rgba(163,230,53,0.12);color:#eafff3;font-weight:600;cursor:pointer"
+      button style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.35);background:rgba(52,211,153,0.14);color:#eafff3;font-weight:600;cursor:pointer" on:click { set onlyVegan = not onlyVegan } {
+        when onlyVegan { span "🥗 Fully vegan" } else { span "🌿 Vegan options" }
+      }
+      button "📍 Near me" style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(163,230,53,0.4);background:rgba(163,230,53,0.12);color:#eafff3;font-weight:600;cursor:pointer" on:click { locate }
       a "Sign in" href="/login" visible="guest" style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.25);color:#9fe9c6;text-decoration:none;font-weight:600"
       span "🌱 Signed in" visible="auth" style="padding:0.55rem 0.75rem;border-radius:10px;border:1px solid rgba(52,211,153,0.25);color:#34d399;font-weight:600;font-size:0.85rem"
       button "Sign out" visible="auth" on:click { logout } style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(251,113,133,0.4);background:rgba(251,113,133,0.12);color:#fb7185;font-weight:600;cursor:pointer"
@@ -89,6 +91,21 @@ page / {
           }
           else {
             div "Move the map to discover vegan places." style="padding:1.4rem 1rem;color:rgba(234,255,243,0.5);text-align:center;font-size:0.9rem"
+          }
+        }
+
+        div visible="auth" style="border-top:1px solid rgba(52,211,153,0.18);max-height:42%;overflow-y:auto;padding:0.7rem 0.8rem" {
+          div "★ My favorites" style="font-weight:700;color:#a3e635;font-size:0.85rem;margin-bottom:0.5rem"
+          data favorites = get /api/favorites auth {
+            empty {
+              div "No saved spots yet — tap ♥ Save on a place." style="color:rgba(234,255,243,0.5);font-size:0.82rem;padding:0.3rem"
+            }
+          }
+          each favorites -> fav {
+            div style="display:flex;justify-content:space-between;align-items:center;gap:8px;padding:0.4rem 0.5rem;border:1px solid rgba(163,230,53,0.14);border-radius:10px;margin-bottom:0.4rem" {
+              span "${fav.name}" style="font-size:0.84rem"
+              a "↗ Map" href="https://www.google.com/maps/dir/?api=1&destination=${fav.lat},${fav.lon}" target="_blank" style="color:#a3e635;font-size:0.76rem;text-decoration:none"
+            }
           }
         }
       }

--- a/examples/vegan-maps.nyx
+++ b/examples/vegan-maps.nyx
@@ -63,7 +63,9 @@ page / {
       input bind="query" placeholder="Filter visible places…" style="flex:1;min-width:200px;max-width:420px;padding:0.6rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.22);background:rgba(255,255,255,0.04);color:#eafff3;outline:none"
       button "🥗 Fully vegan" on:click -> set onlyVegan = not onlyVegan style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.35);background:rgba(52,211,153,0.14);color:#eafff3;font-weight:600;cursor:pointer"
       button "📍 Near me" on:click -> locate style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(163,230,53,0.4);background:rgba(163,230,53,0.12);color:#eafff3;font-weight:600;cursor:pointer"
-      a "Sign in" href="/login" style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.25);color:#9fe9c6;text-decoration:none;font-weight:600"
+      a "Sign in" href="/login" visible="guest" style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(52,211,153,0.25);color:#9fe9c6;text-decoration:none;font-weight:600"
+      span "🌱 Signed in" visible="auth" style="padding:0.55rem 0.75rem;border-radius:10px;border:1px solid rgba(52,211,153,0.25);color:#34d399;font-weight:600;font-size:0.85rem"
+      button "Sign out" visible="auth" on:click { logout } style="padding:0.55rem 0.9rem;border-radius:10px;border:1px solid rgba(251,113,133,0.4);background:rgba(251,113,133,0.12);color:#fb7185;font-weight:600;cursor:pointer"
     }
 
     div style="display:flex;flex:1;min-height:0" {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabudde/nyxcode",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabudde/nyxcode",
-      "version": "0.54.0",
+      "version": "0.54.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabudde/nyxcode",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "description": "NyxCode — The AI-native programming language. One .nyx file = full-stack app. 3.5x fewer tokens than Next.js.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6529,6 +6529,14 @@ async function __nyx_sse(url, body, onChunk, onDone) {
         );
       }
     }
+    // Normalise NyxCode logical operators to JS so handler expressions like
+    // `set x = not y`, `a and b`, `a or b` produce valid JavaScript (they used to
+    // emit the literal words `not`/`and`/`or` → SyntaxError → the handler silently
+    // did nothing). Word-boundary only; runs before state resolution.
+    result = result
+      .replace(/\bnot\b/g, "!")
+      .replace(/\band\b/g, "&&")
+      .replace(/\bor\b/g, "||");
     for (const [name] of this.stateVars) {
       // Replace standalone occurrences (not inside other words)
       // v0.50 fix: Don't replace when preceded by '.' (property access like .value)

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -750,6 +750,14 @@ export class Compiler {
     const scriptContent = [reactiveRuntime, js].filter(Boolean).join("\n");
     const hasScript = scriptContent.trim().length > 0 || renderCalls.length > 0;
 
+    // v0.27.0 — visible=auth/guest toggle script. Inject here (body already compiled,
+    // so _hasVisibleDirective is known); dedupe makes it idempotent across paths.
+    if (this._hasVisibleDirective) {
+      this.headInjections.push(
+        '<script>document.addEventListener("DOMContentLoaded",function(){var t=localStorage.getItem("token");document.querySelectorAll("[data-visible]").forEach(function(el){var v=el.getAttribute("data-visible");if(v==="auth")el.style.display=t?"":"none";if(v==="guest")el.style.display=t?"none":""})});</script>',
+      );
+    }
+
     // Issue #97: dedupe singleton meta tags so page-level `meta {}` overrides site-level.
     const dedupedInjections = this.dedupeHeadInjections(this.headInjections);
     const headExtra =
@@ -5401,6 +5409,14 @@ export class Compiler {
     const scriptContent = [reactiveRuntime, js].filter(Boolean).join("\n");
     const hasScript = scriptContent.trim().length > 0 || renderCalls.length > 0;
 
+    // v0.27.0 — visible=auth/guest toggle script. Inject here (body already compiled,
+    // so _hasVisibleDirective is known); dedupe makes it idempotent across paths.
+    if (this._hasVisibleDirective) {
+      this.headInjections.push(
+        '<script>document.addEventListener("DOMContentLoaded",function(){var t=localStorage.getItem("token");document.querySelectorAll("[data-visible]").forEach(function(el){var v=el.getAttribute("data-visible");if(v==="auth")el.style.display=t?"":"none";if(v==="guest")el.style.display=t?"none":""})});</script>',
+      );
+    }
+
     // Issue #97: dedupe singleton meta tags so page-level `meta {}` overrides site-level.
     const dedupedInjections = this.dedupeHeadInjections(this.headInjections);
     const headExtra =
@@ -6305,6 +6321,13 @@ async function __nyx_sse(url, body, onChunk, onDone) {
       path = this.resolveStateRefs(path);
       // S2 fix (Tyto review): URL sanitization — block javascript: protocol
       return `(function(){var u='${path.replace(/'/g, "\\'")}';if(/^javascript:/i.test(u))return;window.location.href=u})()`;
+    }
+
+    // v0.54: logout [ "/path" ] — clear the JWT and go home (or to a path).
+    if (action === 'logout' || action.startsWith('logout ')) {
+      const rest = action.slice(7).trim().replace(/^"|"$/g, '').replace(/^'|'$/g, '');
+      const dest = (rest || '/').replace(/'/g, "\\'");
+      return `(function(){try{localStorage.removeItem('token')}catch(e){}window.location.href='${dest}'})()`;
     }
 
     // v0.54: locate [ "mapId" ] — geolocate the user and recenter a native <map>.

--- a/src/tests/v0541-auth-ui.test.ts
+++ b/src/tests/v0541-auth-ui.test.ts
@@ -1,0 +1,48 @@
+/**
+ * v0.54 — auth-aware UI: `visible=auth/guest` toggle script (single-page) + `logout`.
+ *
+ * Bugs found while debugging "login looks like it does nothing":
+ *  - `visible="auth"/"guest"` emitted the data attribute but the runtime toggle
+ *    script was only injected on the multi-page path — single-page apps showed
+ *    elements unconditionally, so there was no visible logged-in/out state.
+ *  - There was no native way to log out.
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { Parser } from '../parser.js';
+import { Lexer } from '../lexer.js';
+import { Compiler } from '../compiler.js';
+
+function compile(src: string) {
+  return new Compiler().compile(new Parser(new Lexer(src).tokenize()).parse());
+}
+
+describe('v0.54: visible=auth/guest', () => {
+  it('injects the token-based toggle script on a single-page app', () => {
+    const { html } = compile(
+      `page / {\n  a "Sign in" href="/login" visible="guest"\n  span "Hi" visible="auth"\n}`,
+    );
+    assert.ok(html.includes('[data-visible]'), 'toggle script must be injected');
+    assert.ok(html.includes("localStorage.getItem(\"token\")"), 'toggle keys off the JWT');
+    assert.ok(/data-visible="guest"/.test(html), 'guest element tagged');
+    assert.ok(/data-visible="auth"/.test(html), 'auth element tagged');
+  });
+
+  it('auth elements start hidden (revealed only when a token exists)', () => {
+    const { html } = compile(`page / {\n  span "Hi" visible="auth"\n}`);
+    assert.ok(/data-visible="auth" style="display:none"/.test(html), 'auth hidden by default');
+  });
+});
+
+describe('v0.54: logout action', () => {
+  it('clears the token and redirects home', () => {
+    const { html } = compile(`page / {\n  button "Out" on:click { logout }\n}`);
+    assert.ok(html.includes("removeItem('token')"), 'should clear the JWT');
+    assert.ok(html.includes("window.location.href='/'"), 'should go home');
+  });
+
+  it('logout to a custom path', () => {
+    const { html } = compile(`page / {\n  button "Out" on:click { logout "/login" }\n}`);
+    assert.ok(html.includes("window.location.href='/login'"), 'should honor the path');
+  });
+});

--- a/src/tests/v0541-auth-ui.test.ts
+++ b/src/tests/v0541-auth-ui.test.ts
@@ -46,3 +46,19 @@ describe('v0.54: logout action', () => {
     assert.ok(html.includes("window.location.href='/login'"), 'should honor the path');
   });
 });
+
+describe('v0.54: handler logical operators compile to valid JS', () => {
+  it('set x = not y emits ! (not the literal word "not")', () => {
+    const { html } = compile(`page / {\n  state on = true\n  button "T" on:click { set on = not on }\n}`);
+    const m = html.match(/onclick="([^"]*state\.on[^"]*)"/);
+    assert.ok(m, 'toggle onclick should exist');
+    assert.ok(!/\bnot\b/.test(m[1]), 'must not emit the literal word not');
+    assert.doesNotThrow(() => new Function('__nyx', m[1]), 'must be valid JS');
+  });
+
+  it('and / or compile to && / ||', () => {
+    const { html } = compile(`page / {\n  state a = true\n  state b = false\n  button "T" on:click { set a = a and b }\n}`);
+    const m = html.match(/onclick="([^"]*state\.a =[^"]*)"/);
+    assert.ok(m && m[1].includes('&&'), 'and should become &&');
+  });
+});


### PR DESCRIPTION
## Problem
Login and registration *technically* worked (a JWT was issued and stored in localStorage), but the UI gave **no visible feedback**, so it looked broken: after submitting you stayed put, and the header still said "Sign in".

Investigated end-to-end in a real headless-Chrome session and found three issues:

1. **`success -> navigate "/"` was dropped by the form compiler** — parsed without capturing its value, and `navigate` wasn't a recognized form success action. So forms stored the token but never redirected. (Fixed in the prior commit; `navigate`/`go` are now first-class.)
2. **`visible="auth"/"guest"` didn't work on single-page apps** — the token-based show/hide toggle script was only injected on the multi-page path. So a single-page app never reflected logged-in state.
3. **No native way to log out.**

## Fixes
- Inject the `visible=auth/guest` toggle script on the single-page path too (idempotent via head dedupe).
- New native **`logout`** action: `on:click { logout }` clears the JWT + redirects (`logout "/path"` optional).
- `examples/vegan-maps.nyx` header now shows **Sign in ↔ Signed in / Sign out**.

## Verified (real headless-Chrome run, live site)
- logged out → "Sign in" visible, "Sign out" hidden
- register → redirect to `/`, token stored, **"Sign out" visible**, "Sign in" hidden
- save favorite (logged in) → 201, user auto-set from JWT
- click "Sign out" → token cleared, "Sign in" visible again
- duplicate email → "User already exists"; wrong password → "Invalid credentials"

744 unit tests green. Live at https://vegan.heynyx.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)